### PR TITLE
Added isFrequent weighting when calculating the average climate rating

### DIFF
--- a/procedures.sql
+++ b/procedures.sql
@@ -19,12 +19,23 @@ BEGIN
                         ) AS ClimateRank
                     FROM (
                             SELECT Country.Name AS CountryName,
-                                AVG(ClimateRating) AS AvgClimateRating
-                            FROM UserInput
-                                JOIN Country ON UserInput.CountryID = Country.CountryID
-                            WHERE DateVisitedFrom >= startDate
-                                AND DateVisitedTo <= endDate
-                            GROUP BY Country.Name
+                                SUM(
+                                    CASE
+                                    WHEN UserInfo.isFrequent = TRUE THEN ClimateRating * 2
+                                    ELSE ClimateRating
+                                    END
+                                ) / SUM(
+                                    CASE
+                                    WHEN UserInfo.isFrequent = TRUE THEN 2
+                                    ELSE 1
+                                    END
+                                ) AS AvgClimateRating
+                            FROM Country
+                                LEFT JOIN UserInput ON UserInput.CountryID = Country.CountryID
+                                LEFT JOIN UserInfo ON UserInput.UserID = UserInfo.UserID
+                            WHERE DateVisitedFrom > startDate
+                            AND DateVisitedTo < endDate
+                            GROUP BY CountryName
                         ) AvgClimateRatings
                     UNION
                     SELECT CountryName,


### PR DESCRIPTION
This pull request introduces significant changes to the calculation of climate ratings in the backend and SQL procedures. The main changes include the addition of a new named tuple, modifications to the climate rating calculation to account for frequent users, and updates to SQL queries to reflect these changes.

### Backend Changes:

* [`backend/controllers/ranking_controller.py`](diffhunk://#diff-0a24e46442c4521da64a753b47317dc5f9d33b6437273f0264ad0246c2fbf71aR20-R24): Added a new named tuple `AverageClimateRatingOfCountry` to store the country and its average climate rating.
* [`backend/controllers/ranking_controller.py`](diffhunk://#diff-0a24e46442c4521da64a753b47317dc5f9d33b6437273f0264ad0246c2fbf71aL90-R127): Modified the `get_average_climate_rating_of_country` function to calculate climate ratings with a weighted average for frequent users and adjusted the SQL query to use fixed date ranges.

### SQL Procedure Changes:

* [`procedures.sql`](diffhunk://#diff-4c00b623b0740687f21b7b3c9906d3fd15025488fb769603f34f87765859d937L22-R38): Updated the SQL procedure to calculate the average climate rating using a weighted average for frequent users. This includes changes to the `SELECT` statement and `JOIN` conditions.