### PR TITLE
Added text ranking to average climate rating table from stored procedure

### DIFF
--- a/backend/controllers/ranking_controller.py
+++ b/backend/controllers/ranking_controller.py
@@ -22,6 +22,11 @@ class AverageClimateRatingOfCountry(NamedTuple):
     average_climate_rating: float
 
 
+class TextRanking(NamedTuple):
+    CountryName: str
+    Label: str
+
+
 @ranking_blueprint.route("/ranking", methods=["GET"])
 @jwt_required()
 def get_ranking():
@@ -125,8 +130,21 @@ def get_average_climate_rating_of_country():
             },
         ).fetchall()
     )  # type: ignore
+    text_rankings: list[TextRanking] = db.session.execute(
+        text(
+            """ CALL CalculateCountriesWithWorstClimateImpact(
+                :startDate, :endDate
+            )"""
+        ),
+        {"startDate": date_visited_from, "endDate": date_visited_to},
+    ).fetchall()  # type: ignore
+    text_ranking_map = {row.CountryName: row.Label for row in text_rankings}
     response_data = [
-        {"country": row.country, "averageClimateRating": row.average_climate_rating}
+        {
+            "country": row.country,
+            "averageClimateRating": row.average_climate_rating,
+            "label": text_ranking_map.get(row.country, ""),
+        }
         for row in average_climate_rating_of_country
     ]
     return jsonify(response_data), 200

--- a/backend/controllers/ranking_controller.py
+++ b/backend/controllers/ranking_controller.py
@@ -114,8 +114,8 @@ def get_average_climate_rating_of_country():
                     FROM UserInput
                         JOIN Country ON UserInput.CountryID = Country.CountryID
                         JOIN UserInfo ON UserInput.UserID = UserInfo.UserID
-                    WHERE DateVisitedFrom > '1900-01-01'
-                        AND DateVisitedTo < '2100-01-01'
+                    WHERE DateVisitedFrom > :date_visited_from
+                        AND DateVisitedTo < :date_visited_to
                     GROUP BY country
                     ORDER BY average_climate_rating DESC"""
             ),

--- a/frontend/src/pages/Ranking/components/AverageClimateRatingTable.tsx
+++ b/frontend/src/pages/Ranking/components/AverageClimateRatingTable.tsx
@@ -25,6 +25,7 @@ function AverageClimateRatingTable() {
         <tr>
           <th>Country</th>
           <th>Average Climate Rating</th>
+          <th>Climate impact</th>
         </tr>
       </thead>
       <tbody>
@@ -32,6 +33,7 @@ function AverageClimateRatingTable() {
           <tr key={averageClimateRating.country}>
             <td>{averageClimateRating.country}</td>
             <td>{averageClimateRating.averageClimateRating}</td>
+            <td>{averageClimateRating.label}</td>
           </tr>
         ))}
       </tbody>

--- a/frontend/src/types/Ranking/AverageClimateRating.ts
+++ b/frontend/src/types/Ranking/AverageClimateRating.ts
@@ -1,6 +1,7 @@
 interface AverageClimateRating {
   country: string;
   averageClimateRating: number;
+  label: string;
 }
 
 export default AverageClimateRating;


### PR DESCRIPTION
This pull request includes several changes to the climate ranking feature in both the backend and frontend. The most important changes involve adding a new text ranking feature, modifying the climate rating query to use dynamic date parameters, and updating the frontend to display the new climate impact label.

Backend changes:

* Added a new `TextRanking` class to `backend/controllers/ranking_controller.py` to represent the country name and label.
* Modified the `get_average_climate_rating_of_country` function to use dynamic date parameters in the SQL query.
* Enhanced the `get_average_climate_rating_of_country` function to include text rankings by calling a stored procedure and mapping the results to the response data.

Frontend changes:

* Updated the `AverageClimateRatingTable` component to display the new climate impact label in the table.
* Modified the `AverageClimateRating` interface to include the new `label` field.